### PR TITLE
Remove dependency on scikit-learn.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -44,7 +44,6 @@ install_requires =
   numba
   numpy>=1.17,<1.21
   matplotlib
-  scikit-learn
   pandas
   PyWavelets
 


### PR DESCRIPTION
It appears to not be used and is giving me issues when deploying CSIKit to Raspberry Pi.

I cannot find any reference to this package anywhere in the code. Am I not looking hard enough or is it indeed superfluous? 