### PR TITLE
add print metadata support

### DIFF
--- a/CSIKit/csi/csimetadata.py
+++ b/CSIKit/csi/csimetadata.py
@@ -12,3 +12,22 @@ class CSIMetadata:
         self.average_sample_rate = data["average_sample_rate"]
         self.average_rssi = data["average_rssi"]
         self.csi_shape = data["csi_shape"]
+
+    def __str__(self):
+
+        s = ""
+        s += "Hardware: {}\n".format(self.chipset)
+        s += "Backend: {}\n".format(self.backend)
+        s += "Bandwidth: {}MHz\n".format(self.bandwidth)
+        s += "Antenna Configuration: {}\n".format(self.antenna_config)
+        s += "Frame Count: {}\n".format(self.frames)
+        s += "Subcarrier Count: {}\n".format(self.subcarriers)
+        s += "Length: {0:.2f}s\n".format(self.time_length)
+        s += "Average Sample Rate: {0:.2f}Hz\n".format(self.average_sample_rate)
+
+        if self.average_rssi != -1:
+            s += "Average RSSI: {}dBm\n".format(self.average_rssi)
+
+        s += "CSI Shape: {}".format((self.frames, *self.csi_shape))
+
+        return s


### PR DESCRIPTION
With defining the `__str__` function in metadata class, you can print the metadata
```
print(csi_data.get_metadata())
```

The format is same as `tools/get_info.py`